### PR TITLE
Code and README tweaks for Golang

### DIFF
--- a/fullstack/go/price-calculator/README.md
+++ b/fullstack/go/price-calculator/README.md
@@ -8,46 +8,26 @@ http://take-home-test.herokuapp.com/new-product-engineer
 ## Dependencies
 
 * Go 1.16
-* Some kind of bash terminal to leverage the `tools.sh` script
+* Some kind of shell terminal (e.g. `bash`, `zsh`) to leverage the `tools.sh` script
 
-## Install & run
+## Your mission, 007
 
-Certain functions are not implemented, and when called will panic with
-the message "not implemented".
+Some functions are not implemented (that's where you come in!). These will cause the
+tests to fail with the message "not implemented".
 
-For the application to work, these will need to be completed. Once you are
-ready, use the following instructions to run the application.
+For the application to work, these will need to be implemented. Once you are ready,
+see below on how to run the application and its tests.
 
-### The easy way
+We recommend implementing the functions in the below order. It is of course up to you!
 
-Use the `tools.sh` script provided (make sure it has executable permissions):
+* managers.ProductBasePriceManager.Lookup
+* models.CartItem.CalculatePrice
+* managers.CartManager.CalculateTotalPrices
 
-```sh
-./tools.sh calculator \
-    --base-prices=testdata/base-prices.json \
-    --cart=testdata/cart-4560.json
-```
+We also highly recommend using an IDE with Golang autocomplete enabled. It is a very
+useful feature and can save time for more interesting things during your interview!
 
-### Alternatively
-
-* To build from the project root `GOBIN=$(pwd)/bin go install ./cmd/calculator` 
-* Then run `./bin/calculator --cart=<file> --base-prices=<file>`
-
-## Run the test suite
-
-Certain tests will fail due to the `NotImplementedError`. Running the test suite
-will show you which parts of the application need to be finished.
-
-### The easy way
-
-* Run tests: `./tools.sh test`
-* Run tests with coverage: `./tools.sh cover`
-
-### Alternatively
-
-* Run manually: `go test -v ./...`
-
-## Test data
+## The data
 
 The required test data can be found in the `./testdata` folder. It contains
 a file of product base prices (`base-prices.json`), and several example carts
@@ -62,3 +42,38 @@ to use them or integrate them, and they are not used at all by the existing code
 They're just here in case you find them helpful, and can be safely ignored if
 you don't.
 
+## Running the application
+
+### The easy way
+
+Use the `tools.sh` script provided (make sure it has executable permissions).
+
+To build the application:
+
+```sh
+./tools.sh install
+```
+
+To run it:
+
+```sh
+./tools.sh calculator --base-prices=testdata/base-prices.json --cart=testdata/cart-4560.json
+```
+
+Note: there are many cart test files. The application will need to run with all of them.
+
+### The alternative way
+
+* To build from the project root `GOBIN=$(pwd)/bin go install ./cmd/calculator` 
+* Then run `./bin/calculator --cart=<file> --base-prices=<file>`
+
+## Running the test suite
+
+### The easy way
+
+* Run tests: `./tools.sh test`
+* Run tests with coverage: `./tools.sh cover`
+
+### The alternative way
+
+* Run manually: `go test -v ./...`

--- a/fullstack/go/price-calculator/managers/baseprice.go
+++ b/fullstack/go/price-calculator/managers/baseprice.go
@@ -2,6 +2,7 @@ package managers
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 
 	"redbubble.com/calculator/models"
@@ -36,5 +37,6 @@ func (mgr ProductBasePriceManager) Lookup(
 	productType string,
 	options map[string]string,
 ) (price models.ProductBasePrice, found bool) {
-	panic("not implemented")
+	log.Fatalf("not implemented")
+	return models.ProductBasePrice{}, false
 }

--- a/fullstack/go/price-calculator/managers/cart.go
+++ b/fullstack/go/price-calculator/managers/cart.go
@@ -2,6 +2,7 @@ package managers
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 
 	"redbubble.com/calculator/models"
@@ -30,5 +31,6 @@ func CartManagerFromFile(basePriceManager ProductBasePriceManager, cartFile stri
 }
 
 func (mgr CartManager) CalculateTotalPrices() int {
-	panic("not implemented")
+	log.Fatalf("not implemented")
+	return 0
 }

--- a/fullstack/go/price-calculator/managers/cart_test.go
+++ b/fullstack/go/price-calculator/managers/cart_test.go
@@ -8,23 +8,22 @@ import (
 func TestLookupPriceAndCalculateTotal(t *testing.T) {
 	basePriceMgr := loadBasePriceManager(t)
 
-	for idx, tc := range []struct {
-		amount int
-	}{
-		{9363},
-		{9500},
-		{11356},
-	} {
+	for idx, expectedTotal := range []int{4560, 9363, 9500, 11356} {
+		cartFileName := fmt.Sprintf("../testdata/cart-%d.json", expectedTotal)
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			cartFileName := fmt.Sprintf("../testdata/cart-%d.json", tc.amount)
-			cartMgr, err := CartManagerFromFile(basePriceMgr, cartFileName)
-			if err != nil {
-				t.Fatal(err)
-			}
-			result := cartMgr.CalculateTotalPrices()
-			if result != tc.amount {
-				t.Fatal(result, "!=", tc.amount)
-			}
+			testCartByFile(basePriceMgr, cartFileName, expectedTotal, t)
 		})
+	}
+}
+
+func testCartByFile(basePriceMgr ProductBasePriceManager, fileName string, expectedTotal int, t *testing.T) {
+	cartMgr, err := CartManagerFromFile(basePriceMgr, fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := cartMgr.CalculateTotalPrices()
+	if result != expectedTotal {
+		t.Fatal(result, "!=", expectedTotal)
 	}
 }

--- a/fullstack/go/price-calculator/models/cart.go
+++ b/fullstack/go/price-calculator/models/cart.go
@@ -1,11 +1,13 @@
 package models
 
+import "log"
+
 type CartItem struct {
 	ProductType string                 `json:"product-type"`
 	Options     map[string]interface{} `json:"options"`
 
 	// The artist markup in percentile. E.g. 20 would be 20% in markup.
-	ArtistMarkup int `json:"artist_markup"`
+	ArtistMarkup int `json:"artist-markup"`
 
 	// The quantity of this item.
 	Quantity int `json:"quantity"`
@@ -15,5 +17,6 @@ type CartItem struct {
 }
 
 func (item CartItem) CalculatePrice() int {
-	panic("not implemented")
+	log.Fatalf("not implemented")
+	return 0
 }

--- a/fullstack/go/price-calculator/testdata/cart-4560.json
+++ b/fullstack/go/price-calculator/testdata/cart-4560.json
@@ -1,0 +1,12 @@
+[
+  {
+    "product-type": "hoodie",
+    "options": {
+      "size": "small",
+      "colour": "white",
+      "print-location": "front"
+    },
+    "artist-markup": 20,
+    "quantity": 1
+  }
+]

--- a/fullstack/go/price-calculator/tools.sh
+++ b/fullstack/go/price-calculator/tools.sh
@@ -25,7 +25,9 @@ cmd-cover() {
 
 cmd="${1:-}"
 if [[ -z "$cmd" ]]; then
-    typeset -f | grep '^cmd-' | awk '{print $1}'
+    echo >&2 "Available commands:"
+    echo
+    typeset -f | grep '^cmd-' | awk '{split($1, a ,"-"); print "-",a[2]}'
     exit 2
 fi
 "cmd-$cmd" "${@:2}"


### PR DESCRIPTION
Some of the things I have tweaked based on feedback:

- tools.sh default output is misleading... has cmd- prefix
- restore 4560 cart test data file
- switch from panics in tests to error messages (avoid stack dumps)
- update artist_markup key -> artist-markup
- We should list the methods to be implemented in the confluence page in a reasonable sequence so that we can offer hints in the right order if they get stuck without us having to think too hard
- Autocomplete is a game changer for candidates, we should mention that it's recommended to have this working. Will had it set up and it made things look effortless but most of the candidates we see don't have this up and running.